### PR TITLE
Rename package to "cascading-filesystem"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+Cascading Filesystem
+====================
+
 Installation
-============
+------------
 
 Add this package as a dependency in your project's composer.json configuration:
 
@@ -19,9 +22,6 @@ require 'vendor/autoload.php';
 ```
 
 For more information on composer please refer to its [documentation](https://getcomposer.org/doc/).
-
-Cascading Filesystem
-====================
 
 Concept
 -------
@@ -110,13 +110,12 @@ This lists the files of a directory in the merged CFS:
 $files = $cfs->listFiles('code');
 ```
 
-Kohana Modules
-==============
+Modules
+-------
 
-Kohana modules are really just an extended concept of a directory in the cascading filesystem. The additional functionality a module gains is that it can be initialized and classes within it can be autoloaded. Modules provide an easy way to organize your code and make any part more shareable or transportable across different applications.
+Modules are really just an extended concept of a directory in the cascading filesystem. The additional functionality a module gains is that it can be initialized and classes within it can be autoloaded. Modules provide an easy way to organize your code and make any part more shareable or transportable across different applications.
 
-Initialization
---------------
+### Initialization
 
 To initialize all of the enabled modules in the cascading filesystem:
 
@@ -129,8 +128,11 @@ use Kohana\CascadingFilesystem\Initializer\ModulesInitializer;
 
 This should be done before you start using the modules as they may have prerequisites which are fulfilled by initialization.
 
-Autoloading
------------
+#### Specification
+
+If you would like your module to be initialized you must add an `init.php` file at the root. When the user initializes all of their modules, this init file will be included into the PHP script. This is the ideal place to execute any PHP code necessary for the module to function.
+
+### Autoloading
 
 To enable the autoloading of classes inside of modules you must first register the autoloader class by executing its register method:
 
@@ -152,16 +154,7 @@ use Kohana\CascadingFilesystem\Autoloader\LegacyModulesAutoloader;
 
 Now the autoloader is registered you can go ahead and use any classes as if they're already included. There is also an `unregister()` method for unregistering an autoloader after its registration. For more precise control over registering an autoloader, you may enable its `autoload` method directly using `spl_autoload_register()`.
 
-Creating a Module
------------------
-
-To create your own Kohana module you must follow this specification. Other than following these rules, you may add as many custom files and folders to your module as you like.
-
-### Init.php
-
-If you would like your module to be initialized you must add an `init.php` file at the root. When the user initializes all of their modules, this init file will be included into the PHP script. This is the ideal place to execute any PHP code necessary for the module to function.
-
-### Classes
+#### Specification
 
 All classes that need to be autoloaded must follow this specification:
 
@@ -173,8 +166,7 @@ All classes that need to be autoloaded must follow this specification:
 
 If your classes do not follow this convention, they cannot be autoloaded by this package. You would have to manually include your classes or create your own autoloader.
 
-Where to Find Modules
----------------------
+### Where to Find Modules
 
  - [kohana-modules](http://www.kohana-modules.com) - A website dedicated to indexing all Kohana modules with an excellent search and refine system; created by Andrew Hutchings.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Add this package as a dependency in your project's composer.json configuration:
 
 ```json
 require: {
-    "kohana/modules": "~1.0"
+    "kohana/cascading-filesystem": "~1.0"
 }
 ```
 
@@ -72,11 +72,14 @@ Instantiation
 -------------
 
 ```php
+use Kohana\CascadingFilesystem\Filesystem\CascadingFilesystem;
+use Doctrine\Common\Cache\ArrayCache;
+
 // Instantiate cache
-$cache = new Doctrine\Common\Cache\ArrayCache();
+$cache = new ArrayCache();
 
 // Instantiate CFS
-$cfs = new Kohana\Modules\Filesystem\CascadingFilesystem($cache, [
+$cfs = new CascadingFilesystem($cache, [
     'directory/path/one',
     'directory/path/two',
     'directory/path/three',
@@ -118,8 +121,10 @@ Initialization
 To initialize all of the enabled modules in the cascading filesystem:
 
 ```php
+use Kohana\CascadingFilesystem\Initializer\ModulesInitializer;
+
 // Initialize all modules
-(new Kohana\Modules\Initializer\ModulesInitializer($cfs))->initialize();
+(new ModulesInitializer($cfs))->initialize();
 ```
 
 This should be done before you start using the modules as they may have prerequisites which are fulfilled by initialization.
@@ -130,7 +135,7 @@ Autoloading
 To enable the autoloading of classes inside of modules you must first register the autoloader class by executing its register method:
 
 ```php
-use Kohana\Modules\Autoloader\ModulesAutoloader;
+use Kohana\CascadingFilesystem\Autoloader\ModulesAutoloader;
 
 // Register Kohana module autoloader
 (new ModulesAutoloader($cfs))->register();
@@ -139,7 +144,7 @@ use Kohana\Modules\Autoloader\ModulesAutoloader;
 There is also a backwards compatibility autoloader for module classes which still use the old file naming convention (lowercase):
 
 ```php
-use Kohana\Modules\Autoloader\LegacyModulesAutoloader;
+use Kohana\CascadingFilesystem\Autoloader\LegacyModulesAutoloader;
 
 // Register legacy Kohana module autoloader
 (new LegacyModulesAutoloader($cfs))->register();

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "kohana/modules",
-    "description": "Kohana modules manager",
+    "name": "kohana/cascading-filesystem",
+    "description": "A virtual filesystem formed from merging multiple directories",
     "license": "BSD-3-Clause",
     "require": {
         "doctrine/cache": "~1.0"
@@ -10,5 +10,5 @@
         "mikey179/vfsStream": "1.4.0",
         "squizlabs/php_codesniffer": "~2.0"
     },
-    "autoload": {"psr-4": {"Kohana\\Modules\\": "src"}}
+    "autoload": {"psr-4": {"Kohana\\CascadingFilesystem\\": "src"}}
 }

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,4 +1,4 @@
 suites:
     kohana_suite:
-        namespace: Kohana\Modules
-        psr4_prefix: Kohana\Modules
+        namespace: Kohana\CascadingFilesystem
+        psr4_prefix: Kohana\CascadingFilesystem

--- a/spec/Autoloader/LegacyModulesAutoloaderSpec.php
+++ b/spec/Autoloader/LegacyModulesAutoloaderSpec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace spec\Kohana\Modules\Autoloader;
+namespace spec\Kohana\CascadingFilesystem\Autoloader;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Kohana\Modules\Filesystem\CascadingFilesystem;
+use Kohana\CascadingFilesystem\Filesystem\CascadingFilesystem;
 
 class LegacyModulesAutoloaderSpec extends ObjectBehavior
 {

--- a/spec/Autoloader/ModulesAutoloaderSpec.php
+++ b/spec/Autoloader/ModulesAutoloaderSpec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace spec\Kohana\Modules\Autoloader;
+namespace spec\Kohana\CascadingFilesystem\Autoloader;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Kohana\Modules\Filesystem\CascadingFilesystem;
+use Kohana\CascadingFilesystem\Filesystem\CascadingFilesystem;
 
 class ModulesAutoloaderSpec extends ObjectBehavior
 {

--- a/spec/Filesystem/CascadingFilesystemSpec.php
+++ b/spec/Filesystem/CascadingFilesystemSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Kohana\Modules\Filesystem;
+namespace spec\Kohana\CascadingFilesystem\Filesystem;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/spec/Initializer/ModulesInitializerSpec.php
+++ b/spec/Initializer/ModulesInitializerSpec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace spec\Kohana\Modules\Initializer;
+namespace spec\Kohana\CascadingFilesystem\Initializer;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Kohana\Modules\Filesystem\CascadingFilesystem;
+use Kohana\CascadingFilesystem\Filesystem\CascadingFilesystem;
 
 class ModulesInitializerSpec extends ObjectBehavior
 {

--- a/src/Autoloader/AbstractModulesAutoloader.php
+++ b/src/Autoloader/AbstractModulesAutoloader.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Kohana\Modules\Autoloader;
+namespace Kohana\CascadingFilesystem\Autoloader;
 
-use Kohana\Modules\Filesystem\CascadingFilesystem;
+use Kohana\CascadingFilesystem\Filesystem\CascadingFilesystem;
 
 /**
  * Abstract modules autoloader.

--- a/src/Autoloader/Autoloader.php
+++ b/src/Autoloader/Autoloader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kohana\Modules\Autoloader;
+namespace Kohana\CascadingFilesystem\Autoloader;
 
 /**
  * Autoloader interface.

--- a/src/Autoloader/LegacyModulesAutoloader.php
+++ b/src/Autoloader/LegacyModulesAutoloader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kohana\Modules\Autoloader;
+namespace Kohana\CascadingFilesystem\Autoloader;
 
 /**
  * Provides autoloading support of classes that follow Kohana's old class

--- a/src/Autoloader/ModulesAutoloader.php
+++ b/src/Autoloader/ModulesAutoloader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kohana\Modules\Autoloader;
+namespace Kohana\CascadingFilesystem\Autoloader;
 
 /**
  * Provides autoloading support for Kohana module classes.

--- a/src/Filesystem/CascadingFilesystem.php
+++ b/src/Filesystem/CascadingFilesystem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kohana\Modules\Filesystem;
+namespace Kohana\CascadingFilesystem\Filesystem;
 
 use Doctrine\Common\Cache\Cache;
 

--- a/src/Initializer/Initializer.php
+++ b/src/Initializer/Initializer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kohana\Modules\Initializer;
+namespace Kohana\CascadingFilesystem\Initializer;
 
 /**
  * Initializer.

--- a/src/Initializer/ModulesInitializer.php
+++ b/src/Initializer/ModulesInitializer.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Kohana\Modules\Initializer;
+namespace Kohana\CascadingFilesystem\Initializer;
 
-use Kohana\Modules\Filesystem\CascadingFilesystem;
+use Kohana\CascadingFilesystem\Filesystem\CascadingFilesystem;
 
 /**
  * Modules Initializer.


### PR DESCRIPTION
Related: https://github.com/kohana/modules/issues/2

Composer package name and namespaces have been changed. The readme has also been changed to primary focus on the cascading filesystem.
