### PR TITLE
Rename getPath() to getRealPath() and getAllPaths() to getAllRealPaths()

### DIFF
--- a/spec/Autoloader/LegacyModulesAutoloaderSpec.php
+++ b/spec/Autoloader/LegacyModulesAutoloaderSpec.php
@@ -18,7 +18,7 @@ class LegacyModulesAutoloaderSpec extends ObjectBehavior
         $path = 'classes/foo.php';
         $real_path = '/real/'.$path;
 
-        $cfs->getPath($path)->willReturn($real_path);
+        $cfs->getRealPath($path)->willReturn($real_path);
 
         $cfs->load($real_path)->shouldBeCalled();
         $this->autoload('foo')->shouldReturn(true);
@@ -29,7 +29,7 @@ class LegacyModulesAutoloaderSpec extends ObjectBehavior
         $path = 'classes/foo/bar/baz.php';
         $real_path = '/real/'.$path;
 
-        $cfs->getPath($path)->willReturn($real_path);
+        $cfs->getRealPath($path)->willReturn($real_path);
 
         $cfs->load($real_path)->shouldBeCalled();
         $this->autoload('foo_bar_baz')->shouldReturn(true);
@@ -37,7 +37,7 @@ class LegacyModulesAutoloaderSpec extends ObjectBehavior
 
     function it_returns_false_when_failing_to_load_a_class($cfs)
     {
-        $cfs->getPath('classes/foo.php')->willReturn(false);
+        $cfs->getRealPath('classes/foo.php')->willReturn(false);
 
         $this->autoload('foo')->shouldReturn(false);
     }

--- a/spec/Autoloader/ModulesAutoloaderSpec.php
+++ b/spec/Autoloader/ModulesAutoloaderSpec.php
@@ -18,7 +18,7 @@ class ModulesAutoloaderSpec extends ObjectBehavior
         $path = 'classes/Foo.php';
         $real_path = '/real/'.$path;
 
-        $cfs->getPath($path)->willReturn($real_path);
+        $cfs->getRealPath($path)->willReturn($real_path);
 
         $cfs->load($real_path)->shouldBeCalled();
         $this->autoload('Foo')->shouldReturn(true);
@@ -29,7 +29,7 @@ class ModulesAutoloaderSpec extends ObjectBehavior
         $path = 'classes/Foo/Bar/Baz.php';
         $real_path = '/real/'.$path;
 
-        $cfs->getPath($path)->willReturn($real_path);
+        $cfs->getRealPath($path)->willReturn($real_path);
 
         $cfs->load($real_path)->shouldBeCalled();
         $this->autoload('Foo\Bar\Baz')->shouldReturn(true);
@@ -40,7 +40,7 @@ class ModulesAutoloaderSpec extends ObjectBehavior
         $path = 'classes/Foo.php';
         $real_path = '/real/'.$path;
 
-        $cfs->getPath($path)->willReturn($real_path);
+        $cfs->getRealPath($path)->willReturn($real_path);
 
         $cfs->load($real_path)->shouldBeCalled();
         $this->autoload('\Foo')->shouldReturn(true);
@@ -51,7 +51,7 @@ class ModulesAutoloaderSpec extends ObjectBehavior
         $path = 'classes/Name_Space/Foo/Bar/Baz.php';
         $real_path = '/real/'.$path;
 
-        $cfs->getPath($path)->willReturn($real_path);
+        $cfs->getRealPath($path)->willReturn($real_path);
 
         $cfs->load($real_path)->shouldBeCalled();
         $this->autoload('Name_Space\Foo_Bar_Baz')->shouldReturn(true);
@@ -59,7 +59,7 @@ class ModulesAutoloaderSpec extends ObjectBehavior
 
     function it_returns_false_when_failing_to_find_a_class($cfs)
     {
-        $cfs->getPath('classes/Foo.php')->willReturn(false);
+        $cfs->getRealPath('classes/Foo.php')->willReturn(false);
 
         $this->autoload('Foo')->shouldReturn(false);
     }

--- a/spec/Filesystem/CascadingFilesystemSpec.php
+++ b/spec/Filesystem/CascadingFilesystemSpec.php
@@ -73,32 +73,32 @@ class CascadingFilesystemSpec extends ObjectBehavior
         $this->getBasePaths()->shouldEqual($base_paths);
     }
 
-    function it_gets_a_path_with_highest_precedence($cache)
+    function it_gets_a_real_file_path($cache)
     {
         $path = 'src/House.php';
-        $cache_id = 'getPath_'.$path;
+        $cache_id = 'getRealPath_'.$path;
         $real_path = vfsStream::url('root/dir4/src/House.php');
 
         $cache->fetch($cache_id)->willReturn(false);
         $cache->save($cache_id, $real_path)->willReturn(true);
 
-        $this->getPath($path)->shouldReturn($real_path);
+        $this->getRealPath($path)->shouldReturn($real_path);
     }
 
-    function it_returns_false_when_a_path_is_not_found($cache)
+    function it_returns_false_when_a_real_file_path_is_not_found($cache)
     {
         $path = 'nonexistent/file.txt';
-        $cache_id = 'getPath_'.$path;
+        $cache_id = 'getRealPath_'.$path;
 
         $cache->fetch($cache_id)->willReturn(false);
 
-        $this->getPath($path)->shouldReturn(false);
+        $this->getRealPath($path)->shouldReturn(false);
     }
 
-    function it_gets_all_paths($cache)
+    function it_gets_all_real_file_paths($cache)
     {
         $path = 'src/House.php';
-        $cache_id = 'getAllPaths_'.$path;
+        $cache_id = 'getAllRealPaths_'.$path;
         $real_paths = [
             vfsStream::url('root/dir4/src/House.php'),
             vfsStream::url('root/dir1/src/House.php'),
@@ -107,19 +107,19 @@ class CascadingFilesystemSpec extends ObjectBehavior
         $cache->fetch($cache_id)->willReturn(false);
         $cache->save($cache_id, $real_paths)->willReturn(true);
 
-        $this->getAllPaths('src/House.php')->shouldReturn($real_paths);
+        $this->getAllRealPaths($path)->shouldReturn($real_paths);
     }
 
-    function it_returns_an_empty_array_when_no_paths_are_found($cache)
+    function it_returns_an_empty_array_when_no_real_file_paths_are_found($cache)
     {
         $path = 'nonexistent/file.md';
-        $cache_id = 'getAllPaths_'.$path;
+        $cache_id = 'getAllRealPaths_'.$path;
         $real_paths = [];
 
         $cache->fetch($cache_id)->willReturn(false);
         $cache->save($cache_id, $real_paths)->willReturn(true);
 
-        $this->getAllPaths($path)->shouldReturn($real_paths);
+        $this->getAllRealPaths($path)->shouldReturn($real_paths);
     }
 
     function it_lists_files()

--- a/spec/Initializer/ModulesInitializerSpec.php
+++ b/spec/Initializer/ModulesInitializerSpec.php
@@ -21,7 +21,7 @@ class ModulesInitializerSpec extends ObjectBehavior
             'third/path',
         ];
 
-        $cfs->getAllPaths('init.php')->willReturn($paths);
+        $cfs->getAllRealPaths('init.php')->willReturn($paths);
 
         foreach ($paths as $path) {
             $cfs->load($path)->shouldBecalled(1);

--- a/src/Autoloader/AbstractModulesAutoloader.php
+++ b/src/Autoloader/AbstractModulesAutoloader.php
@@ -62,7 +62,7 @@ abstract class AbstractModulesAutoloader implements Autoloader
     protected function loadClass($file_path)
     {
         // Get real file path
-        $real_path = $this->cfs->getPath($file_path);
+        $real_path = $this->cfs->getRealPath($file_path);
 
         // Load the file if class exists
         if ($real_path) {

--- a/src/Filesystem/CascadingFilesystem.php
+++ b/src/Filesystem/CascadingFilesystem.php
@@ -5,7 +5,8 @@ namespace Kohana\CascadingFilesystem\Filesystem;
 use Doctrine\Common\Cache\Cache;
 
 /**
- * The cascading filesystem.
+ * A filesystem which is formed from multiple directories being virtually merged
+ * together. Files in latter defined directories take precedence when merging.
  */
 class CascadingFilesystem
 {
@@ -59,16 +60,15 @@ class CascadingFilesystem
     }
 
     /**
-     * Finds a file in the cascading filesystem which matches the path and has
-     * the highest precedence.
+     * Gets the file's real path from its virtual path.
      *
-     * @param string $relative_path Path to a file
-     * @return string Real file path
+     * @param string $path Virtual path to file
+     * @return string|false Real absolute path to the file
      */
-    public function getPath($relative_path)
+    public function getRealPath($path)
     {
         // Generate cache key
-        $cache_key = 'getPath_'.$relative_path;
+        $cache_key = 'getRealPath_'.$path;
 
         // Return cached result if it exists
         if (($cached_data = $this->cache->fetch($cache_key)) !== false) {
@@ -77,14 +77,14 @@ class CascadingFilesystem
 
         // Search base paths for matching path
         foreach (array_reverse($this->base_paths) as $base_path) {
-            $absolute_path = $base_path.$relative_path;
+            $real_path = $base_path.$path;
 
             // If file was found
-            if (is_file($absolute_path)) {
+            if (is_file($real_path)) {
                 // Cache the file path
-                $this->cache->save($cache_key, $absolute_path);
+                $this->cache->save($cache_key, $real_path);
 
-                return $absolute_path;
+                return $real_path;
             }
         }
 
@@ -92,16 +92,15 @@ class CascadingFilesystem
     }
 
     /**
-     * Finds all real file paths in the cascading filesystem which match the
-     * path.
+     * Gets all of the real file paths from their virtual path.
      *
-     * @param string $relative_path Path to a file
-     * @return array All real file paths found, ordered by precedence descending
+     * @param string $path Virtual path to file
+     * @return array All real file paths ordered by precedence descending
      */
-    public function getAllPaths($relative_path)
+    public function getAllRealPaths($path)
     {
         // Generate cache key
-        $cache_key = 'getAllPaths_'.$relative_path;
+        $cache_key = 'getAllRealPaths_'.$path;
 
         // Return cached result if it exists
         if (($cached_data = $this->cache->fetch($cache_key)) !== false) {
@@ -112,11 +111,11 @@ class CascadingFilesystem
         $found = [];
 
         foreach (array_reverse($this->base_paths) as $base_path) {
-            $absolute_path = $base_path.$relative_path;
+            $real_path = $base_path.$path;
 
             // Add to array if file exists
-            if (is_file($absolute_path)) {
-                $found[] = $absolute_path;
+            if (is_file($real_path)) {
+                $found[] = $real_path;
             }
         }
 

--- a/src/Initializer/ModulesInitializer.php
+++ b/src/Initializer/ModulesInitializer.php
@@ -33,7 +33,7 @@ class ModulesInitializer implements Initializer
     public function initialize()
     {
         // Get all initialization file locations
-        $init_file_paths = $this->cfs->getAllPaths($this->init_file_path);
+        $init_file_paths = $this->cfs->getAllRealPaths($this->init_file_path);
 
         // Load initialization files
         foreach ($init_file_paths as $path) {


### PR DESCRIPTION
This is a much more descriptive name for the two methods rather than the generic 'getPath'. It makes it much clearer that these methods get the real file path from their virtual one.
