### PR TITLE
Skip only vfsStream failures on HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
   - 5.6
   - hhvm
 
-matrix:
-  allow_failures:
-    - php: hhvm
-
 install:
   - composer install --prefer-dist
 

--- a/spec/Filesystem/CascadingFilesystemSpec.php
+++ b/spec/Filesystem/CascadingFilesystemSpec.php
@@ -6,11 +6,18 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Doctrine\Common\Cache\ArrayCache;
 use org\bovigo\vfs\vfsStream;
+use PhpSpec\Exception\Example\SkippingException;
 
 class CascadingFilesystemSpec extends ObjectBehavior
 {
     function let(ArrayCache $cache)
     {
+        if (defined('HHVM_VERSION')) {
+            throw new SkippingException(
+                'Skipped due to incomplete vfsStream support on HHVM - https://github.com/facebook/hhvm/issues/1971'
+            );
+        }
+
         vfsStream::setup('root', null, [
             'dir1' => [
                 'src' => [
@@ -149,4 +156,5 @@ class CascadingFilesystemSpec extends ObjectBehavior
     {
         $this->load(vfsStream::url('root/dir4/src/House.php'));
     }
+
 }


### PR DESCRIPTION
Rather than ignoring all HHVM failures as in 1b2e619, just skip the specs that currently fail due to vfsStream issues. This will ensure any actual breaking changes on HHVM are still spotted in future.
